### PR TITLE
INT-760: Update guzzle as v6 conflicts with Integration API where guzzle is v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
Both projects are vendors of silk, so guzzle must be at the same version